### PR TITLE
Adding github user and email inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
   github_token:
     description: Github token
     default: ${{ github.token }}
+  github_user:
+    description: Github user
+    default: github-actions[bot]
+  github_email:
+    description: Github email
+    default: github-actions[bot]@users.noreply.github.com
   template:
     description: |
       The location of the template file used to build the form, useful for ease of maintenance.
@@ -127,8 +133,8 @@ runs:
     - name: Commit & Push
       id: commit
       run: |
-        git config user.name github-actions[bot]
-        git config user.email github-actions[bot]@users.noreply.github.com
+        git config user.name ${{ inputs.github_user }}
+        git config user.email ${{ inputs.github_email }}
         PUSHED=false
         if [[ ${{ steps.process.outputs.modified }} == true ]] && [[ ${{ inputs.dry_run != 'no-commit' }} == true ]]; then
           echo "Committing ${{ inputs.form }}"


### PR DESCRIPTION
# Description:

This pull-request adds two new inputs to the action.yml file: user and email. These inputs will allow users to specify the user name and email address associated with the commits made by the action.

This feature is particularly useful for actions that generate commits or perform other git operations. By including this information, it will be easier to track who made the changes and when they were made.

The user and email inputs are optional, but if they are not provided, the action will fall back to using the default user and email associated with the GitHub account that created the token.

Please review and let me know if any changes are needed. Thank you!