### PR TITLE
Pull strategy input for git operation to support for rebase

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,14 @@ inputs:
       - no-write
       - no-commit
       - no-push
+  pull_strategy:
+    description: |
+      The git pull strategy to use before pushing changes. Use `ff-only` for fast-forward only (default), or `rebase` to rebase local changes.
+    type: choice
+    default: ff-only
+    options:
+      - ff-only
+      - rebase
 
 # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs#example-defining-outputs-for-a-job
 outputs:
@@ -140,7 +148,11 @@ runs:
           git commit -m "$MSG"
           if [[ ${{ inputs.dry_run != 'no-push' }} == true ]]; then
             echo "Pushing to upstream"
-            git pull --ff-only
+            if [[ "${{ inputs.pull_strategy }}" == "rebase" ]]; then
+              git pull --rebase
+            else
+              git pull --ff-only
+            fi
             git push
             PUSHED=true
           fi


### PR DESCRIPTION
# What

This pull request introduces a new input option to the `action.yml` file, allowing users to specify a Git pull strategy (`ff-only` or `rebase`) when pushing changes. It also updates the script logic to respect this new input.

# Why
When updating multiple issue templates in parallel, due to complexity or size, fast forward will not be possible.  This PR adds an optional input parameter, pull_strategy, in order to overwrite the default fast-forward behavior and choose rebase

## Enhancements to Git pull behavior:

* **New input option for pull strategy**: Added `pull_strategy` as a choice input in `action.yml`, with options `ff-only` (default) and `rebase`. This allows users to define the desired Git pull strategy before pushing changes.
* **Conditional logic for pull strategy**: Updated the `runs` section in `action.yml` to include conditional logic for executing `git pull` with either `--rebase` or `--ff-only`, based on the value of the `pull_strategy` input.